### PR TITLE
feat: upload multiple pdf files

### DIFF
--- a/src/pages/upload/UploadPage.tsx
+++ b/src/pages/upload/UploadPage.tsx
@@ -15,16 +15,38 @@ import { UploadIcon, XIcon } from "../../components/Icons";
 import { getResourceLink } from "./utils";
 
 const SUPER_ADMIN = "SUPER_ADMIN";
+const MAX_CONCURRENT_UPLOADS = 3;
+
+type PendingStatus = "pending" | "uploading" | "success" | "error";
+
+interface PendingUpload {
+  id: string;
+  file: File;
+  status: PendingStatus;
+  error?: string;
+}
+
+function validateFile(file: File): string | null {
+  if (!isPdfFile(file)) {
+    return "PDF 파일만 업로드할 수 있습니다.";
+  }
+  if (!isWithinSizeLimit(file)) {
+    return `파일 크기는 ${MAX_FILE_SIZE_MB}MB 이하여야 합니다.`;
+  }
+  return null;
+}
+
+function nextId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
 
 export default function UploadPage() {
   const hasToken = !!getToken();
   const { data, isLoading, isError } = useVerifyToken(hasToken);
 
-  const [file, setFile] = useState<File | null>(null);
+  const [pending, setPending] = useState<PendingUpload[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [validationError, setValidationError] = useState<string | null>(null);
   const [uploadedList, setUploadedList] = useState<UploadResponse[]>([]);
   const [listLoading, setListLoading] = useState(true);
   const [listError, setListError] = useState<string | null>(null);
@@ -80,56 +102,39 @@ export default function UploadPage() {
     return <Navigate to="/" replace />;
   }
 
-  const validateAndSubmit = async () => {
-    setValidationError(null);
-    setUploadError(null);
-
-    if (!file) {
-      setValidationError("PDF 파일을 선택해주세요.");
-      return;
-    }
-    if (!isPdfFile(file)) {
-      setValidationError(
-        "PDF 파일만 업로드할 수 있습니다. (.pdf 또는 application/pdf)",
-      );
-      return;
-    }
-    if (!isWithinSizeLimit(file)) {
-      setValidationError(`파일 크기는 ${MAX_FILE_SIZE_MB}MB 이하여야 합니다.`);
-      return;
-    }
-
-    const titleFromFile = file.name.trim() || "제목 없음";
-    try {
-      setIsUploading(true);
-      await uploadPdf(file, titleFromFile);
-      setFile(null);
-      if (inputRef.current) inputRef.current.value = "";
-      fetchList();
-    } catch (err) {
-      setUploadError(
-        err instanceof Error ? err.message : "업로드에 실패했습니다.",
-      );
-    } finally {
-      setIsUploading(false);
-    }
+  const addFiles = (files: File[]) => {
+    if (files.length === 0) return;
+    setPending((prev) => {
+      const existingNames = new Set(prev.map((p) => p.file.name));
+      const toAdd: PendingUpload[] = [];
+      for (const f of files) {
+        if (existingNames.has(f.name)) continue;
+        existingNames.add(f.name);
+        const error = validateFile(f);
+        toAdd.push({
+          id: nextId(),
+          file: f,
+          status: error ? "error" : "pending",
+          error: error ?? undefined,
+        });
+      }
+      return [...prev, ...toAdd];
+    });
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const chosen = e.target.files?.[0];
-    if (!chosen) return;
-    setFile(chosen);
-    setValidationError(null);
+    const chosen = e.target.files;
+    if (!chosen || chosen.length === 0) return;
+    addFiles(Array.from(chosen));
     e.target.value = "";
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
-    const dropped = e.dataTransfer.files?.[0];
-    if (!dropped) return;
-    setFile(dropped);
-    setValidationError(null);
+    const dropped = e.dataTransfer.files;
+    if (!dropped || dropped.length === 0) return;
+    addFiles(Array.from(dropped));
   };
 
   const handleDragOver = (e: React.DragEvent) => {
@@ -141,10 +146,74 @@ export default function UploadPage() {
     setIsDragging(false);
   };
 
-  const handleRemoveFile = () => {
-    setFile(null);
-    setValidationError(null);
-    if (inputRef.current) inputRef.current.value = "";
+  const handleRemove = (id: string) => {
+    setPending((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const uploadSingle = async (item: PendingUpload): Promise<void> => {
+    setPending((prev) =>
+      prev.map((p) =>
+        p.id === item.id ? { ...p, status: "uploading", error: undefined } : p,
+      ),
+    );
+    try {
+      const title = item.file.name.trim() || "제목 없음";
+      await uploadPdf(item.file, title);
+      setPending((prev) =>
+        prev.map((p) =>
+          p.id === item.id ? { ...p, status: "success", error: undefined } : p,
+        ),
+      );
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "업로드에 실패했습니다.";
+      setPending((prev) =>
+        prev.map((p) =>
+          p.id === item.id ? { ...p, status: "error", error: message } : p,
+        ),
+      );
+    }
+  };
+
+  const runQueue = async (items: PendingUpload[]) => {
+    if (items.length === 0) return;
+    setIsUploading(true);
+    try {
+      let cursor = 0;
+      const worker = async () => {
+        while (cursor < items.length) {
+          const idx = cursor++;
+          await uploadSingle(items[idx]);
+        }
+      };
+      const workers = Array.from(
+        { length: Math.min(MAX_CONCURRENT_UPLOADS, items.length) },
+        () => worker(),
+      );
+      await Promise.all(workers);
+      setPending((prev) => prev.filter((p) => p.status !== "success"));
+      fetchList();
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleUploadAll = () => {
+    const targets = pending.filter((p) => p.status === "pending");
+    void runQueue(targets);
+  };
+
+  const handleRetry = (id: string) => {
+    const target = pending.find((p) => p.id === id);
+    if (!target) return;
+    const error = validateFile(target.file);
+    if (error) {
+      setPending((prev) =>
+        prev.map((p) => (p.id === id ? { ...p, status: "error", error } : p)),
+      );
+      return;
+    }
+    void runQueue([{ ...target, status: "pending", error: undefined }]);
   };
 
   const handleDelete = async (id: string) => {
@@ -167,14 +236,46 @@ export default function UploadPage() {
     }
   };
 
+  const pendingCount = pending.filter((p) => p.status === "pending").length;
+  const hasUploadable = pendingCount > 0 && !isUploading;
+
+  const renderStatusBadge = (status: PendingStatus) => {
+    switch (status) {
+      case "pending":
+        return (
+          <span className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 text-xs shrink-0">
+            대기
+          </span>
+        );
+      case "uploading":
+        return (
+          <span className="px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 text-xs shrink-0">
+            업로드 중...
+          </span>
+        );
+      case "success":
+        return (
+          <span className="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs shrink-0">
+            완료
+          </span>
+        );
+      case "error":
+        return (
+          <span className="px-2 py-0.5 rounded-full bg-red-100 text-red-700 text-xs shrink-0">
+            실패
+          </span>
+        );
+    }
+  };
+
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">파일 업로드</h1>
           <p className="mt-2 text-sm text-gray-600">
-            PDF 파일을 선택하면 파일 이름이 제목으로 저장됩니다. (최대{" "}
-            {MAX_FILE_SIZE_MB}MB)
+            PDF 파일을 선택하면 파일 이름이 제목으로 저장됩니다. 여러 개를 한
+            번에 선택할 수 있습니다. (각 파일 최대 {MAX_FILE_SIZE_MB}MB)
           </p>
         </div>
 
@@ -184,7 +285,6 @@ export default function UploadPage() {
           </div>
 
           <div className="p-6 space-y-6">
-            {/* Drop Zone (단일 PDF) */}
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 파일 <span className="text-red-500">*</span>
@@ -215,6 +315,7 @@ export default function UploadPage() {
                   ref={inputRef}
                   type="file"
                   accept=".pdf,application/pdf"
+                  multiple
                   className="hidden"
                   onChange={handleFileChange}
                 />
@@ -222,47 +323,76 @@ export default function UploadPage() {
                   <UploadIcon className="w-12 h-12 text-gray-400" />
                 </div>
                 <p className="mt-3 text-sm font-medium text-gray-700">
-                  {file
-                    ? file.name
-                    : "클릭하거나 PDF 파일을 여기에 드래그하세요"}
+                  클릭하거나 PDF 파일을 여기에 드래그하세요 (여러 개 선택 가능)
                 </p>
                 <p className="mt-1 text-xs text-gray-500">
-                  PDF만 업로드 가능, 최대 {MAX_FILE_SIZE_MB}MB
+                  PDF만 업로드 가능, 각 파일 최대 {MAX_FILE_SIZE_MB}MB
                 </p>
               </div>
-              {file && (
-                <div className="mt-2 flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3 text-sm">
-                  <span className="text-gray-700 truncate flex-1 min-w-0">
-                    {file.name} ({(file.size / 1024).toFixed(1)} KB)
-                  </span>
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleRemoveFile();
-                    }}
-                    className="ml-3 text-red-600 hover:text-red-700 font-medium shrink-0"
-                  >
-                    제거
-                  </button>
+
+              {pending.length > 0 && (
+                <div className="mt-3 space-y-2">
+                  {pending.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 px-4 py-3 text-sm"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="text-gray-700 truncate min-w-0">
+                            {item.file.name}
+                          </span>
+                          {renderStatusBadge(item.status)}
+                        </div>
+                        <p className="mt-0.5 text-xs text-gray-500 truncate">
+                          {(item.file.size / 1024).toFixed(1)} KB
+                          {item.error ? ` · ${item.error}` : ""}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        {item.status === "error" && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleRetry(item.id);
+                            }}
+                            disabled={isUploading}
+                            className="text-[#df3326] hover:text-[#c72a1f] font-medium disabled:opacity-50"
+                          >
+                            재시도
+                          </button>
+                        )}
+                        {item.status !== "uploading" && (
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleRemove(item.id);
+                            }}
+                            className="text-red-600 hover:text-red-700 font-medium"
+                          >
+                            제거
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
             </div>
 
-            {/* 검증/업로드 에러 */}
-            {(validationError || uploadError) && (
-              <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                {validationError || uploadError}
-              </div>
-            )}
-
             <button
               type="button"
-              onClick={validateAndSubmit}
-              disabled={isUploading || !file}
+              onClick={handleUploadAll}
+              disabled={!hasUploadable}
               className="w-full px-6 py-2.5 bg-[#df3326] text-white font-medium rounded-md hover:bg-[#c72a1f] active:scale-[0.98] transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              {isUploading ? "업로드 중..." : "업로드"}
+              {isUploading
+                ? "업로드 중..."
+                : pendingCount > 0
+                  ? `업로드 (${pendingCount}개)`
+                  : "업로드"}
             </button>
           </div>
         </div>

--- a/src/pages/upload/UploadPage.tsx
+++ b/src/pages/upload/UploadPage.tsx
@@ -15,7 +15,7 @@ import { UploadIcon, XIcon } from "../../components/Icons";
 import { getResourceLink } from "./utils";
 
 const SUPER_ADMIN = "SUPER_ADMIN";
-const MAX_CONCURRENT_UPLOADS = 3;
+const MAX_CONCURRENT_UPLOADS = 10;
 
 type PendingStatus = "pending" | "uploading" | "success" | "error";
 
@@ -40,6 +40,10 @@ function nextId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function fileKey(f: File): string {
+  return `${f.name}:${f.size}:${f.lastModified}`;
+}
+
 export default function UploadPage() {
   const hasToken = !!getToken();
   const { data, isLoading, isError } = useVerifyToken(hasToken);
@@ -52,6 +56,7 @@ export default function UploadPage() {
   const [listError, setListError] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [limitNotice, setLimitNotice] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const fetchList = () => {
@@ -104,22 +109,29 @@ export default function UploadPage() {
 
   const addFiles = (files: File[]) => {
     if (files.length === 0) return;
-    setPending((prev) => {
-      const existingNames = new Set(prev.map((p) => p.file.name));
-      const toAdd: PendingUpload[] = [];
-      for (const f of files) {
-        if (existingNames.has(f.name)) continue;
-        existingNames.add(f.name);
-        const error = validateFile(f);
-        toAdd.push({
-          id: nextId(),
-          file: f,
-          status: error ? "error" : "pending",
-          error: error ?? undefined,
-        });
-      }
-      return [...prev, ...toAdd];
-    });
+    const existingKeys = new Set(pending.map((p) => fileKey(p.file)));
+    const toAdd: PendingUpload[] = [];
+    for (const f of files) {
+      const key = fileKey(f);
+      if (existingKeys.has(key)) continue;
+      existingKeys.add(key);
+      const error = validateFile(f);
+      toAdd.push({
+        id: nextId(),
+        file: f,
+        status: error ? "error" : "pending",
+        error: error ?? undefined,
+      });
+    }
+    const available = Math.max(MAX_CONCURRENT_UPLOADS - pending.length, 0);
+    if (toAdd.length > available) {
+      setLimitNotice(
+        `한 번에 최대 ${MAX_CONCURRENT_UPLOADS}개까지만 업로드할 수 있습니다.`,
+      );
+    } else {
+      setLimitNotice(null);
+    }
+    setPending((prev) => [...prev, ...toAdd.slice(0, available)]);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -179,18 +191,7 @@ export default function UploadPage() {
     if (items.length === 0) return;
     setIsUploading(true);
     try {
-      let cursor = 0;
-      const worker = async () => {
-        while (cursor < items.length) {
-          const idx = cursor++;
-          await uploadSingle(items[idx]);
-        }
-      };
-      const workers = Array.from(
-        { length: Math.min(MAX_CONCURRENT_UPLOADS, items.length) },
-        () => worker(),
-      );
-      await Promise.all(workers);
+      await Promise.all(items.map((item) => uploadSingle(item)));
       setPending((prev) => prev.filter((p) => p.status !== "success"));
       fetchList();
     } finally {
@@ -274,8 +275,9 @@ export default function UploadPage() {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">파일 업로드</h1>
           <p className="mt-2 text-sm text-gray-600">
-            PDF 파일을 선택하면 파일 이름이 제목으로 저장됩니다. 여러 개를 한
-            번에 선택할 수 있습니다. (각 파일 최대 {MAX_FILE_SIZE_MB}MB)
+            PDF 파일을 선택하면 파일 이름이 제목으로 저장됩니다. 한 번에 최대{" "}
+            {MAX_CONCURRENT_UPLOADS}개까지 업로드할 수 있습니다. (각 파일 최대{" "}
+            {MAX_FILE_SIZE_MB}MB)
           </p>
         </div>
 
@@ -323,12 +325,17 @@ export default function UploadPage() {
                   <UploadIcon className="w-12 h-12 text-gray-400" />
                 </div>
                 <p className="mt-3 text-sm font-medium text-gray-700">
-                  클릭하거나 PDF 파일을 여기에 드래그하세요 (여러 개 선택 가능)
+                  클릭하거나 PDF 파일을 여기에 드래그하세요 (최대{" "}
+                  {MAX_CONCURRENT_UPLOADS}개까지 업로드 가능)
                 </p>
                 <p className="mt-1 text-xs text-gray-500">
                   PDF만 업로드 가능, 각 파일 최대 {MAX_FILE_SIZE_MB}MB
                 </p>
               </div>
+
+              {limitNotice && (
+                <p className="mt-2 text-sm text-red-600">{limitNotice}</p>
+              )}
 
               {pending.length > 0 && (
                 <div className="mt-3 space-y-2">


### PR DESCRIPTION
<ul>
<li>make uploading multiple pdf files</li>
</ul>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 여러 PDF를 한 번에 선택해 업로드 대기열로 관리할 수 있게 되었습니다.
  * 각 파일의 상태(대기, 업로드 중, 성공, 실패)가 항목별로 표시됩니다.
  * 업로드 진행 중에도 여러 파일을 순차적으로, 일부는 동시에 처리할 수 있습니다.

* **개선 사항**
  * 실패한 파일은 다시 시도할 수 있고, 업로드 전에는 개별 항목을 제거할 수 있습니다.
  * 업로드 버튼에 대기 중인 파일 수가 표시되며, 선택 안내 문구가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->