### PR TITLE
feat: add configurable chatbot widget sizing and launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --test tests/*.test.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/public/loader.js
+++ b/public/loader.js
@@ -76,8 +76,8 @@
     widgetKey: ds.widgetKey || "dev",
     position: ds.position === "left" ? "left" : "right",
     offset: clampInt(ds.offset, 18, 0, 80),
-    width: clampInt(ds.width, 360, 280, 520),
-    height: clampInt(ds.height, 520, 360, 860),
+    width: clampInt(ds.width, 360, 320, 520),
+    height: clampInt(ds.height, 520, 420, 860),
     hideButton: parseBoolean(ds.hideButton),
     resizable: parseBoolean(ds.resizable, true),
     theme: ds.theme || "light",
@@ -365,8 +365,8 @@
   }
 
   function resize(width, height) {
-    config.width = clampInt(width, config.width, 280, 520);
-    config.height = clampInt(height, config.height, 360, 860);
+    config.width = clampInt(width, config.width, 320, 520);
+    config.height = clampInt(height, config.height, 420, 860);
     applyResponsive();
     return { width: config.width, height: config.height };
   }

--- a/public/loader.js
+++ b/public/loader.js
@@ -214,7 +214,6 @@
     }
   }
   applyResponsive();
-  mq.addEventListener?.("change", applyResponsive);
 
   const iframe = document.createElement("iframe");
   // pageUrl을 URL에 포함시켜 postMessage 타이밍에 의존하지 않고 즉시 사용 가능하게 함
@@ -241,9 +240,15 @@
     cursor:${config.position === "right" ? "nwse-resize" : "nesw-resize"};
     touch-action:none;
     z-index:1;
-    display:${config.resizable ? "block" : "none"};
+    display:${!mq.matches && config.resizable ? "block" : "none"};
   `;
   wrap.appendChild(resizeHandle);
+
+  mq.addEventListener?.("change", () => {
+    applyResponsive();
+    resizeHandle.style.display =
+      !mq.matches && config.resizable ? "block" : "none";
+  });
 
   // ---- 상태 ----
   let isOpen = false;

--- a/public/loader.js
+++ b/public/loader.js
@@ -76,8 +76,8 @@
     widgetKey: ds.widgetKey || "dev",
     position: ds.position === "left" ? "left" : "right",
     offset: clampInt(ds.offset, 18, 0, 80),
-    width: clampInt(ds.width, 360, 320, 520),
-    height: clampInt(ds.height, 520, 420, 860),
+    width: clampInt(ds.width, 360, 320, 640),
+    height: clampInt(ds.height, 520, 420, 720),
     hideButton: parseBoolean(ds.hideButton),
     resizable: parseBoolean(ds.resizable, true),
     theme: ds.theme || "light",
@@ -365,8 +365,8 @@
   }
 
   function resize(width, height) {
-    config.width = clampInt(width, config.width, 320, 520);
-    config.height = clampInt(height, config.height, 420, 860);
+    config.width = clampInt(width, config.width, 320, 640);
+    config.height = clampInt(height, config.height, 420, 720);
     applyResponsive();
     return { width: config.width, height: config.height };
   }

--- a/public/loader.js
+++ b/public/loader.js
@@ -79,7 +79,7 @@
     width: clampInt(ds.width, 360, 280, 520),
     height: clampInt(ds.height, 520, 360, 860),
     hideButton: parseBoolean(ds.hideButton),
-    resizable: parseBoolean(ds.resizable),
+    resizable: parseBoolean(ds.resizable, true),
     theme: ds.theme || "light",
     buttonIcon: buttonIcon,
     // 색상 옵션들

--- a/public/loader.js
+++ b/public/loader.js
@@ -9,6 +9,11 @@
     return Math.min(max, Math.max(min, val));
   }
 
+  function parseBoolean(v, fallback = false) {
+    if (v == null || v === "") return fallback;
+    return !["false", "0", "no", "off"].includes(String(v).toLowerCase());
+  }
+
   // ---- utils: 색상 검증 ----
   function validateColor(color, fallback) {
     if (!color) return fallback;
@@ -73,6 +78,8 @@
     offset: clampInt(ds.offset, 18, 0, 80),
     width: clampInt(ds.width, 360, 280, 520),
     height: clampInt(ds.height, 520, 360, 860),
+    hideButton: parseBoolean(ds.hideButton),
+    resizable: parseBoolean(ds.resizable),
     theme: ds.theme || "light",
     buttonIcon: buttonIcon,
     // 색상 옵션들
@@ -90,6 +97,10 @@
   console.log("[loader.js] 최종 config:", config);
 
   const BTN_SIZE = 56;
+
+  function desktopPanelBottom() {
+    return config.offset + (config.hideButton ? 0 : BTN_SIZE + 12);
+  }
 
   // ---- 2) launcher button ----
   const btn = document.createElement("button");
@@ -124,6 +135,7 @@
       '<svg fill="#ffffff" viewBox="0 -64 640 640" xmlns="http://www.w3.org/2000/svg" stroke="#ffffff" style="width: 34px; height: auto;"><g id="SVGRepo_bgCarrier" stroke-width="0"></g><g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"></g><g id="SVGRepo_iconCarrier"><path d="M32,224H64V416H32A31.96166,31.96166,0,0,1,0,384V256A31.96166,31.96166,0,0,1,32,224Zm512-48V448a64.06328,64.06328,0,0,1-64,64H160a64.06328,64.06328,0,0,1-64-64V176a79.974,79.974,0,0,1,80-80H288V32a32,32,0,0,1,64,0V96H464A79.974,79.974,0,0,1,544,176ZM264,256a40,40,0,1,0-40,40A39.997,39.997,0,0,0,264,256Zm-8,128H192v32h64Zm96,0H288v32h64ZM456,256a40,40,0,1,0-40,40A39.997,39.997,0,0,0,456,256Zm-8,128H384v32h64ZM640,256V384a31.96166,31.96166,0,0,1-32,32H576V224h32A31.96166,31.96166,0,0,1,640,256Z"></path></g></svg>',
   };
   btn.innerHTML = buttonIconSVG[config.buttonIcon] || buttonIconSVG.logo;
+  btn.style.display = config.hideButton ? "none" : "flex";
 
   // hover/press 효과
   btn.addEventListener(
@@ -157,7 +169,7 @@
   wrap.style.cssText = `
     position:fixed;
     ${config.position}:${config.offset}px;
-    bottom:${config.offset + BTN_SIZE + 12}px;
+    bottom:${desktopPanelBottom()}px;
 
     width:${config.width}px;
     height:${config.height}px;
@@ -196,7 +208,7 @@
       wrap.style.width = config.width + "px";
       wrap.style.height = config.height + "px";
       wrap.style.maxHeight = "";
-      wrap.style.bottom = config.offset + BTN_SIZE + 12 + "px";
+      wrap.style.bottom = desktopPanelBottom() + "px";
       wrap.style[config.position] = config.offset + "px";
       wrap.style.boxShadow = "0 16px 40px rgba(0,0,0,.22)";
     }
@@ -212,6 +224,26 @@
   iframe.style.cssText = `width:100%; height:100%; border:0; background:transparent;`;
   iframe.allow = "clipboard-read; clipboard-write";
   wrap.appendChild(iframe);
+
+  // 데스크톱에서 선택적으로 드래그하여 패널 크기를 조절한다.
+  const resizeHandle = document.createElement("button");
+  resizeHandle.type = "button";
+  resizeHandle.setAttribute("aria-label", "채팅창 크기 조절");
+  resizeHandle.style.cssText = `
+    position:absolute;
+    top:0;
+    ${config.position === "right" ? "left" : "right"}:0;
+    width:20px;
+    height:20px;
+    padding:0;
+    border:0;
+    background:linear-gradient(${config.position === "right" ? "135deg" : "225deg"}, rgba(100,116,139,.55) 0 2px, transparent 2px 5px, rgba(100,116,139,.35) 5px 7px, transparent 7px);
+    cursor:${config.position === "right" ? "nwse-resize" : "nesw-resize"};
+    touch-action:none;
+    z-index:1;
+    display:${config.resizable ? "block" : "none"};
+  `;
+  wrap.appendChild(resizeHandle);
 
   // ---- 상태 ----
   let isOpen = false;
@@ -331,6 +363,50 @@
   function toggle() {
     isOpen ? close() : open();
   }
+
+  function resize(width, height) {
+    config.width = clampInt(width, config.width, 280, 520);
+    config.height = clampInt(height, config.height, 360, 860);
+    applyResponsive();
+    return { width: config.width, height: config.height };
+  }
+
+  function setLauncherVisible(visible) {
+    config.hideButton = !visible;
+    btn.style.display = visible ? "flex" : "none";
+    applyResponsive();
+  }
+
+  resizeHandle.addEventListener("pointerdown", (event) => {
+    if (!config.resizable || mq.matches) return;
+
+    event.preventDefault();
+    resizeHandle.setPointerCapture?.(event.pointerId);
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const startWidth = config.width;
+    const startHeight = config.height;
+
+    const onPointerMove = (moveEvent) => {
+      const horizontalDelta = moveEvent.clientX - startX;
+      resize(
+        startWidth +
+          (config.position === "right" ? -horizontalDelta : horizontalDelta),
+        startHeight - (moveEvent.clientY - startY)
+      );
+    };
+
+    const onPointerUp = (upEvent) => {
+      resizeHandle.releasePointerCapture?.(upEvent.pointerId);
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+  });
 
   btn.addEventListener("click", toggle);
   overlay.addEventListener("click", close);
@@ -498,6 +574,20 @@
     // 위젯 닫기
     close: function () {
       close();
+    },
+
+    // 위젯 패널 크기 변경 (모바일 레이아웃에는 다음 데스크톱 전환 시 적용)
+    resize: function (width, height) {
+      return resize(width, height);
+    },
+
+    // 커스텀 트리거를 사용할 때 기본 런처 표시 여부 제어
+    showLauncher: function () {
+      setLauncherVisible(true);
+    },
+
+    hideLauncher: function () {
+      setLauncherVisible(false);
     },
 
     // 위젯 상태 확인

--- a/src/pages/docs/contents/Customization.tsx
+++ b/src/pages/docs/contents/Customization.tsx
@@ -100,7 +100,7 @@ export default function Customization() {
                   <td className="px-4 py-3 text-sm text-gray-700">
                     데스크톱에서 패널 모서리 드래그 크기 조절 (true / false)
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-500">false</td>
+                  <td className="px-4 py-3 text-sm text-gray-500">true</td>
                 </tr>
               </tbody>
             </table>
@@ -225,7 +225,6 @@ export default function Customization() {
   data-widget-key="wk_live_abc123"
   data-position="right"
   data-button-icon="chat"
-  data-resizable="true"
   data-primary-color="3b82f6"
   data-button-color="2563eb"
   data-user-message-bg="3b82f6"

--- a/src/pages/docs/contents/Customization.tsx
+++ b/src/pages/docs/contents/Customization.tsx
@@ -84,6 +84,24 @@ export default function Customization() {
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-500">logo</td>
                 </tr>
+                <tr>
+                  <td className="px-4 py-3 text-sm font-mono text-gray-900">
+                    data-hide-button
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700">
+                    커스텀 버튼을 사용할 때 기본 런처 숨김 (true / false)
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">false</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-3 text-sm font-mono text-gray-900">
+                    data-resizable
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700">
+                    데스크톱에서 패널 모서리 드래그 크기 조절 (true / false)
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-500">false</td>
+                </tr>
               </tbody>
             </table>
           </div>
@@ -207,6 +225,7 @@ export default function Customization() {
   data-widget-key="wk_live_abc123"
   data-position="right"
   data-button-icon="chat"
+  data-resizable="true"
   data-primary-color="3b82f6"
   data-button-color="2563eb"
   data-user-message-bg="3b82f6"

--- a/src/pages/docs/contents/JavaScriptAPI.tsx
+++ b/src/pages/docs/contents/JavaScriptAPI.tsx
@@ -23,6 +23,7 @@ ChatbotWidget.close();
 
 // 패널 크기 변경 (허용 범위: 320~640 x 420~720px)
 ChatbotWidget.resize(420, 640);
+// 모바일에서는 설정값만 변경되며, 데스크톱 레이아웃으로 전환할 때 적용됩니다.
 
 // 자체 버튼을 사용하는 경우 기본 런처 제어
 ChatbotWidget.hideLauncher();

--- a/src/pages/docs/contents/JavaScriptAPI.tsx
+++ b/src/pages/docs/contents/JavaScriptAPI.tsx
@@ -21,6 +21,13 @@ ChatbotWidget.open();
 // 위젯 닫기
 ChatbotWidget.close();
 
+// 패널 크기 변경 (허용 범위: 280~520 x 360~860px)
+ChatbotWidget.resize(420, 640);
+
+// 자체 버튼을 사용하는 경우 기본 런처 제어
+ChatbotWidget.hideLauncher();
+ChatbotWidget.showLauncher();
+
 // 위젯 상태 확인
 ChatbotWidget.isOpen(); // boolean
 ChatbotWidget.isReady(); // boolean

--- a/src/pages/docs/contents/JavaScriptAPI.tsx
+++ b/src/pages/docs/contents/JavaScriptAPI.tsx
@@ -21,7 +21,7 @@ ChatbotWidget.open();
 // 위젯 닫기
 ChatbotWidget.close();
 
-// 패널 크기 변경 (허용 범위: 320~520 x 420~860px)
+// 패널 크기 변경 (허용 범위: 320~640 x 420~720px)
 ChatbotWidget.resize(420, 640);
 
 // 자체 버튼을 사용하는 경우 기본 런처 제어

--- a/src/pages/docs/contents/JavaScriptAPI.tsx
+++ b/src/pages/docs/contents/JavaScriptAPI.tsx
@@ -21,7 +21,7 @@ ChatbotWidget.open();
 // 위젯 닫기
 ChatbotWidget.close();
 
-// 패널 크기 변경 (허용 범위: 280~520 x 360~860px)
+// 패널 크기 변경 (허용 범위: 320~520 x 420~860px)
 ChatbotWidget.resize(420, 640);
 
 // 자체 버튼을 사용하는 경우 기본 런처 제어

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const loaderSource = readFileSync(new URL("../public/loader.js", import.meta.url), "utf8");
+
+class EventTargetStub {
+  listeners = new Map();
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) ?? [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners.set(
+      type,
+      (this.listeners.get(type) ?? []).filter((candidate) => candidate !== handler),
+    );
+  }
+
+  dispatchEvent(event) {
+    for (const handler of this.listeners.get(event.type) ?? []) handler(event);
+  }
+}
+
+function createStyle() {
+  const style = {};
+  Object.defineProperty(style, "cssText", {
+    set(value) {
+      for (const declaration of value.split(";")) {
+        const separator = declaration.indexOf(":");
+        if (separator === -1) continue;
+        const property = declaration.slice(0, separator).trim();
+        const propertyValue = declaration.slice(separator + 1).trim();
+        if (!property) continue;
+        const camelCase = property.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+        style[camelCase] = propertyValue;
+      }
+    },
+  });
+  return style;
+}
+
+class ElementStub extends EventTargetStub {
+  constructor(tagName) {
+    super();
+    this.tagName = tagName.toUpperCase();
+    this.style = createStyle();
+    this.children = [];
+    this.attributes = {};
+    this.contentWindow = { postMessage() {} };
+  }
+
+  appendChild(child) {
+    this.children.push(child);
+    return child;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = value;
+  }
+}
+
+function loadWidget(dataset = {}) {
+  const window = new EventTargetStub();
+  const body = new ElementStub("body");
+  const script = new ElementStub("script");
+  script.dataset = dataset;
+  script.src = "https://chatbot.gistory.me/loader.js";
+
+  const document = {
+    currentScript: script,
+    body,
+    createElement: (tagName) => new ElementStub(tagName),
+  };
+  Object.assign(window, {
+    self: window,
+    top: window,
+    parent: window,
+    location: {
+      origin: "https://example.com",
+      pathname: "/",
+      href: "https://example.com/page",
+    },
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+  });
+
+  class CustomEventStub {
+    constructor(type, init) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  }
+
+  vm.runInNewContext(loaderSource, {
+    window,
+    document,
+    location: window.location,
+    URL,
+    CustomEvent: CustomEventStub,
+    console: { log() {}, warn() {}, error() {} },
+    requestAnimationFrame: (callback) => callback(),
+  });
+
+  const [overlay, launcher, panel] = body.children;
+  return { window, overlay, launcher, panel };
+}
+
+test("keeps the existing launcher and panel layout by default", () => {
+  const { window, launcher, panel } = loadWidget();
+
+  assert.equal(launcher.style.display, "flex");
+  assert.equal(panel.style.width, "360px");
+  assert.equal(panel.style.height, "520px");
+  assert.equal(panel.style.bottom, "86px");
+  assert.equal(window.ChatbotWidget.getConfig().hideButton, false);
+});
+
+test("supports a custom trigger without reserving space for the launcher", () => {
+  const { window, launcher, panel } = loadWidget({ hideButton: "true" });
+
+  assert.equal(launcher.style.display, "none");
+  assert.equal(panel.style.bottom, "18px");
+
+  window.ChatbotWidget.open();
+  assert.equal(window.ChatbotWidget.isOpen(), true);
+  window.ChatbotWidget.close();
+  assert.equal(window.ChatbotWidget.isOpen(), false);
+
+  window.ChatbotWidget.showLauncher();
+  assert.equal(launcher.style.display, "flex");
+  assert.equal(panel.style.bottom, "86px");
+});
+
+test("resizes within the documented desktop bounds", () => {
+  const { window, panel } = loadWidget({ resizable: "true" });
+
+  const resized = window.ChatbotWidget.resize(450, 700);
+  assert.equal(resized.width, 450);
+  assert.equal(resized.height, 700);
+  assert.equal(panel.style.width, "450px");
+  assert.equal(panel.style.height, "700px");
+
+  const clamped = window.ChatbotWidget.resize(100, 2000);
+  assert.equal(clamped.width, 280);
+  assert.equal(clamped.height, 860);
+});

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -64,7 +64,7 @@ class ElementStub extends EventTargetStub {
   }
 }
 
-function loadWidget(dataset = {}) {
+function loadWidget(dataset = {}, { mobile = false } = {}) {
   const window = new EventTargetStub();
   const body = new ElementStub("body");
   const script = new ElementStub("script");
@@ -76,6 +76,18 @@ function loadWidget(dataset = {}) {
     body,
     createElement: (tagName) => new ElementStub(tagName),
   };
+  const mediaQuery = {
+    matches: mobile,
+    listeners: [],
+    addEventListener(type, handler) {
+      if (type === "change") this.listeners.push(handler);
+    },
+    setMatches(matches) {
+      this.matches = matches;
+      for (const handler of this.listeners) handler({ matches });
+    },
+  };
+
   Object.assign(window, {
     self: window,
     top: window,
@@ -85,7 +97,7 @@ function loadWidget(dataset = {}) {
       pathname: "/",
       href: "https://example.com/page",
     },
-    matchMedia: () => ({ matches: false, addEventListener() {} }),
+    matchMedia: () => mediaQuery,
   });
 
   class CustomEventStub {
@@ -106,7 +118,7 @@ function loadWidget(dataset = {}) {
   });
 
   const [overlay, launcher, panel] = body.children;
-  return { window, overlay, launcher, panel };
+  return { window, overlay, launcher, panel, mediaQuery };
 }
 
 test("keeps the existing launcher and panel layout by default", () => {
@@ -153,4 +165,20 @@ test("resizes within the documented desktop bounds", () => {
   const maximum = window.ChatbotWidget.resize(2000, 2000);
   assert.equal(maximum.width, 640);
   assert.equal(maximum.height, 720);
+});
+
+test("shows the resize handle only for resizable desktop layouts", () => {
+  const { panel, mediaQuery } = loadWidget({}, { mobile: true });
+  const resizeHandle = panel.children[1];
+
+  assert.equal(resizeHandle.style.display, "none");
+
+  mediaQuery.setMatches(false);
+  assert.equal(resizeHandle.style.display, "block");
+
+  mediaQuery.setMatches(true);
+  assert.equal(resizeHandle.style.display, "none");
+
+  const disabled = loadWidget({ resizable: "false" });
+  assert.equal(disabled.panel.children[1].style.display, "none");
 });

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -117,6 +117,8 @@ test("keeps the existing launcher and panel layout by default", () => {
   assert.equal(panel.style.height, "520px");
   assert.equal(panel.style.bottom, "86px");
   assert.equal(window.ChatbotWidget.getConfig().hideButton, false);
+  assert.equal(window.ChatbotWidget.getConfig().resizable, true);
+  assert.equal(panel.children[1].style.display, "block");
 });
 
 test("supports a custom trigger without reserving space for the launcher", () => {

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -151,6 +151,6 @@ test("resizes within the documented desktop bounds", () => {
   assert.equal(minimum.height, 420);
 
   const maximum = window.ChatbotWidget.resize(2000, 2000);
-  assert.equal(maximum.width, 520);
-  assert.equal(maximum.height, 860);
+  assert.equal(maximum.width, 640);
+  assert.equal(maximum.height, 720);
 });

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -146,7 +146,11 @@ test("resizes within the documented desktop bounds", () => {
   assert.equal(panel.style.width, "450px");
   assert.equal(panel.style.height, "700px");
 
-  const clamped = window.ChatbotWidget.resize(100, 2000);
-  assert.equal(clamped.width, 280);
-  assert.equal(clamped.height, 860);
+  const minimum = window.ChatbotWidget.resize(100, 100);
+  assert.equal(minimum.width, 320);
+  assert.equal(minimum.height, 420);
+
+  const maximum = window.ChatbotWidget.resize(2000, 2000);
+  assert.equal(maximum.width, 520);
+  assert.equal(maximum.height, 860);
 });


### PR DESCRIPTION
## Summary

- enable desktop drag resizing by default; integrations can opt out with `data-resizable="false"`
- expose `ChatbotWidget.resize(width, height)` with existing size bounds
- support custom host-app triggers through `data-hide-button`, `hideLauncher()`, and `showLauncher()`
- preserve the current launcher, positioning, desktop dimensions, and mobile layout
- document the new configuration and JavaScript APIs

## Why

Linear [CHA2-6](https://linear.app/infoteam/issue/CHA2-6/채팅-화면-크기-조절) requests adjustable chat sizing. The related `#chatbot` discussion also identified that host apps with their own FAB need to open and close the chatbot without rendering a second built-in FAB.

## Root cause

The loader accepted fixed startup dimensions and already exposed open/close methods, but it could not resize after initialization and always rendered/reserved space for its launcher.

## Verification

- `npm test` — 3 loader regression tests passed
- `npm run lint`
- `npm run build`

The production build completes with the repository's existing large-chunk warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 런처를 기본적으로 숨기거나 필요할 때 표시할 수 있습니다.
  - 데스크톱 위젯 패널의 크기를 직접 조절할 수 있습니다.
  - JavaScript API로 패널 크기 변경 및 런처 표시·숨김을 제어할 수 있습니다.
  - 사용자 지정 트리거를 사용할 때 기본 런처를 숨길 수 있습니다.

- **문서**
  - 런처 숨김, 패널 크기 조절 옵션과 JavaScript API 사용 예시를 추가했습니다.

- **테스트**
  - 위젯 레이아웃, 런처 동작 및 패널 크기 조절을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->